### PR TITLE
Fix for new optimization coach button logic.

### DIFF
--- a/language-info.rkt
+++ b/language-info.rkt
@@ -7,7 +7,6 @@
 
 (require (prefix-in tr: typed-racket/typed-reader))
 (require (prefix-in tr: typed-racket/language-info))
-(require typed-racket/private/oc-button)
 
 (define digimon-lang
   (let ([var "DIGIMON_LANG"])
@@ -29,5 +28,5 @@
 (define digimon-info
   (lambda [key default use-default]
     (case key
-      [(drscheme:toolbar-buttons) (maybe-show-OC)]
+      [(drracket:opt-in-toolbar-buttons) '(optimization-coach)]
       [else (use-default key default)])))


### PR DESCRIPTION
As of Racket 6.9, the optimization coach button is enabled using DrRacket's new opt-in button mechanism. The mechanism OC used before only worked by accident, and was broken by changes to the language-IDE interface in 6.9.

As a result, the old (private) interface that `digimon` was using is gone, which breaks the package (and `schema`, which depends on it) for the upcoming 6.9 release. This PR fixes it.

With this change, the OC button will show up for `digimon` programs as expected, when running Racket 6.9. On earlier versions of Racket, the package will still work, but the button will not show up.

If you want to have the OC button also show up on older versions of Racket, you can set up a version exception in the package catalog, which would direct older versions to a separate branch of the `digimon` repository that uses the old way of enabling OC. But that step is optional, `digimon` programs will continue running as intended on Racket 6.8 and earlier, even with this PR. It's only the OC button that would be affected.